### PR TITLE
为antd-mobile 添加css.web

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export interface Options {
   libraryDirectory?: string
   camel2DashComponentName?: boolean
   camel2UnderlineComponentName?: boolean
+  styleExt?: string
 }
 
 export interface ImportedStruct {
@@ -87,13 +88,13 @@ function createDistAst(struct: ImportedStruct, options: Options) {
   astNodes.push(scriptNode)
 
   if (options.style) {
-    const { style } = options
+    const { style, styleExt } = options
     const styleNode = ts.createImportDeclaration(
       undefined,
       undefined,
       undefined,
       ts.createLiteral(
-        `${libraryName}/lib/${importName}/style/${ style === 'css' ? 'css' : 'index' }.js`
+        `${libraryName}/lib/${importName}/style/${ style === 'css' ? (styleExt ? styleExt : 'css') : 'index' }.js`
       )
     )
 

--- a/test/expect/css.web/index.tsx
+++ b/test/expect/css.web/index.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import Alert from "antd/lib/alert";
+import "antd/lib/alert/style/css.web.js";
+import { default as S } from "antd/lib/affix";
+import "antd/lib/affix/style/css.web.js";
+import AutoComplete from "antd/lib/auto-complete";
+import "antd/lib/auto-complete/style/css.web.js";
+import { Drawer } from 'material-ui';
+import { OtherComponent } from './other';
+import { forEach } from 'lodash';
+export class Test extends React.PureComponent<void, void> {
+    render() {
+        return (<OtherComponent>
+        <Alert message='hello world'/>
+      </OtherComponent>);
+    }
+}

--- a/test/expect/css.web/other.js
+++ b/test/expect/css.web/other.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import Card from "antd/lib/card";
+import "antd/lib/card/style/css.web.js";
+import { default as A } from "antd/lib/alert";
+import "antd/lib/alert/style/css.web.js";
+;
+import { concat } from "lodash";
+export class OtherComponent extends React.PureComponent {
+    render() {
+        return (<Card>
+        <div>this is card</div>
+      </Card>);
+    }
+}

--- a/test/expect/css.web/skip1.ts
+++ b/test/expect/css.web/skip1.ts
@@ -1,0 +1,2 @@
+import 'antd';
+console.log('nothing to do ...');

--- a/test/main.js
+++ b/test/main.js
@@ -57,6 +57,30 @@ describe('should compile with css', () => {
   })
 })
 
+describe('should compile with css', () => {
+  const transformer = transformerFactory({ style: 'css', styleExt: 'css.web' })
+
+  fixtureDir.forEach(v => {
+    it(`compile ${v}`, () => {
+      const sourceCode = fs.readFileSync(resolve(__dirname, 'fixtures', v), 'utf-8')
+
+      const source = ts.createSourceFile(v, sourceCode, ts.ScriptTarget.ES2016, true)
+
+      const result = ts.transform(source, [ transformer ])
+
+      const transformedSourceFile = result.transformed[0]
+
+      const resultCode = printer.printFile(transformedSourceFile)
+
+      const expectCode = fs.readFileSync(resolve(__dirname, 'expect', 'css.web', v), 'utf-8')
+
+      expect(resultCode).to.equal(expectCode)
+
+      result.dispose()
+    })
+  })
+})
+
 describe('should compile without style', () => {
   const transformer = transformerFactory()
 


### PR DESCRIPTION
新版的antd-mobile 的css 文件命名：css.web.js；这个PR支持了styleExt 的option来兼容；