### PR TITLE
update readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ import 'antd/lib/card/style/index.less'
 # Usage
 
 ## With ts-loader
+```js
+//tsconfig.json
+{
+  ...
+  "module": "ESNext",
+  ...
+}
+```
 
 ```js
 // webpack.config.js
@@ -62,6 +70,15 @@ module.exports = {
 ```
 
 ## With awesome-typescript-loader ( >= 3.5.0 )
+```js
+//tsconfig.json
+{
+  ...
+  "module": "ESNext",
+  ...
+}
+```
+
 ```js
 // webpack.config.js
 const tsImportPluginFactory = require('ts-import-plugin')


### PR DESCRIPTION
TS should not transform the `import` statement, otherwise this plugin will not work, because the `import` has been already transform to the `require`.

Fix https://github.com/Brooooooklyn/ts-import-plugin/issues/51