### PR TITLE
improve getImportedStructs to check different condition

### DIFF
--- a/test/expect/camel-2-underline/skip1.ts
+++ b/test/expect/camel-2-underline/skip1.ts
@@ -1,4 +1,5 @@
 import 'antd';
 import mui from 'material-ui';
+import React, { createElement } from 'react';
 import * as _ from 'lodash';
 console.log('nothing to do ...');

--- a/test/expect/css.web/skip1.ts
+++ b/test/expect/css.web/skip1.ts
@@ -1,4 +1,5 @@
 import 'antd';
 import mui from 'material-ui';
+import React, { createElement } from 'react';
 import * as _ from 'lodash';
 console.log('nothing to do ...');

--- a/test/expect/css/skip1.ts
+++ b/test/expect/css/skip1.ts
@@ -1,4 +1,5 @@
 import 'antd';
 import mui from 'material-ui';
+import React, { createElement } from 'react';
 import * as _ from 'lodash';
 console.log('nothing to do ...');

--- a/test/expect/custom-library-resolver/skip1.ts
+++ b/test/expect/custom-library-resolver/skip1.ts
@@ -1,4 +1,5 @@
 import 'antd';
 import mui from 'material-ui';
+import React, { createElement } from 'react';
 import * as _ from 'lodash';
 console.log('nothing to do ...');

--- a/test/expect/less/skip1.ts
+++ b/test/expect/less/skip1.ts
@@ -1,4 +1,5 @@
 import 'antd';
 import mui from 'material-ui';
+import React, { createElement } from 'react';
 import * as _ from 'lodash';
 console.log('nothing to do ...');

--- a/test/expect/lodash/skip1.ts
+++ b/test/expect/lodash/skip1.ts
@@ -1,4 +1,5 @@
 import 'antd';
 import mui from 'material-ui';
+import React, { createElement } from 'react';
 import * as _ from 'lodash';
 console.log('nothing to do ...');

--- a/test/expect/options-array/skip1.ts
+++ b/test/expect/options-array/skip1.ts
@@ -1,4 +1,5 @@
 import 'antd';
 import mui from 'material-ui';
+import React, { createElement } from 'react';
 import * as _ from 'lodash';
 console.log('nothing to do ...');

--- a/test/expect/transform-to-default-import/skip1.ts
+++ b/test/expect/transform-to-default-import/skip1.ts
@@ -1,4 +1,5 @@
 import 'antd';
 import mui from 'material-ui';
+import React, { createElement } from 'react';
 import * as _ from 'lodash';
 console.log('nothing to do ...');

--- a/test/expect/without-style/skip1.ts
+++ b/test/expect/without-style/skip1.ts
@@ -1,4 +1,5 @@
 import 'antd';
 import mui from 'material-ui';
+import React, { createElement } from 'react';
 import * as _ from 'lodash';
 console.log('nothing to do ...');

--- a/test/fixtures/skip1.ts
+++ b/test/fixtures/skip1.ts
@@ -1,5 +1,6 @@
 import 'antd'
 import mui from 'material-ui'
+import React, { createElement } from 'react'
 import * as _ from 'lodash'
 
 console.log('nothing to do ...')


### PR DESCRIPTION
use more neat API insteadof `getChild*` method, and add tests for mixed default and named import

1. check if is ImportClause
2. check if has default import
3. check if has named import
4. check if is namespace import
5. get importName and variableName