### PR TITLE
feat: adds `failIfNotFound` option to allow to fail the build

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ module.exports = {
 
 ## With rollup
 ```js
-import typescript from 'rollup-plugin-typescript2'
+import typescript from 'rollup-plugin-typescript2' // or '@rollup/plugin-typescript'
 import createTransformer from 'ts-import-plugin'
 
 const transformer = createTransformer({
@@ -133,22 +133,32 @@ export default {
 
 `options` can be an object:
 
-- libraryName `string`
+- libraryName `string` - The name of the library in the import. e.g. If using `import { foo } from 'Bar'` 
+the library should be set to 'bar'.
 
   default `'antd'`
 - style `boolean | string | ((path: string) => string)`
 
   default `false`
-- libraryDirectory `string | ((name: string) => string)`
+- libraryDirectory `string | ((name: string) => string)` - The directory within the library to replace the import with.
+e.g. If you have `import { foo } from 'Bar'`, it will be replaced to `import foo from `\`Bar/${libraryDirectory}/foo\``
 
   default `'lib'`
-- camel2DashComponentName `boolean`
+- camel2DashComponentName `boolean` - Builtin method to use to transform the component name. This does transform the
+component name from camelCase to dashed. e.g. `FooBar` gets transformed to `foo-bar`
 
   default `true`
-- camel2UnderlineComponentName `boolean`
+- camel2UnderlineComponentName `boolean` - Builtin method to use to transform the component name. This does transform the
+ component name from camelCase to snake_case. e.g. `FooBar` gets transformed to `foo_bar`
 
   default `false`
-- libraryOverride `boolean`
+- libraryOverride `boolean` - Setting to false (default) prepends the `libraryName` to the `libraryDirectory` (with a path separator)
+ set to true if you want to use the `libraryDirectory` as the full path for the import.
+
+  default `false`
+  
+- failIfNotFound `boolean` - If the component is not found in the library, the full library is imported by default. 
+ set to true to fail the build.
 
   default `false`
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ export interface Options {
   camel2UnderlineComponentName?: boolean
   transformToDefaultImport?: boolean
   resolveContext?: string[]
+  failIfNotFound?: boolean;
 }
 
 export interface ImportedStruct {
@@ -111,6 +112,10 @@ function createDistAst(struct: ImportedStruct, options: Options) {
     })
   } catch (e) {
     canResolveImportPath = false
+    if (options.failIfNotFound) {
+      throw new Error(`Can not find component for library: ${options.libraryName} in ${importPath}`)
+    }
+
     astNodes.push(
       ts.createImportDeclaration(
         undefined,
@@ -168,14 +173,16 @@ function createDistAst(struct: ImportedStruct, options: Options) {
   return astNodes
 }
 
-const defaultOptions = {
+const defaultOptions: Required<Options> = {
   libraryName: 'antd',
   libraryDirectory: 'lib',
   style: false,
   camel2DashComponentName: true,
+  camel2UnderlineComponentName: false,
   transformToDefaultImport: true,
   resolveContext: [],
   libraryOverride: false,
+  failIfNotFound: false,
 }
 
 export function createTransformer(_options: Partial<Options> | Array<Partial<Options>> = {}) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ export interface Options {
   camel2UnderlineComponentName?: boolean
   transformToDefaultImport?: boolean
   resolveContext?: string[]
-  failIfNotFound?: boolean;
+  failIfNotFound?: boolean
 }
 
 export interface ImportedStruct {

--- a/test/fixtures/component-not-found/index.ts
+++ b/test/fixtures/component-not-found/index.ts
@@ -1,0 +1,1 @@
+import { Component } from 'react';

--- a/test/specs.ts
+++ b/test/specs.ts
@@ -5,6 +5,7 @@ import * as ts from 'typescript'
 
 import { createSpec } from './utils'
 import { Options, createTransformer } from '../src'
+import * as fs from "fs"
 
 const suites: { title: string, config: Options | Options[] }[] = [
   {
@@ -133,5 +134,23 @@ test('should throw if custom style resolver thrown', (t) => {
   })
 
   const transpile = () => ts.transform(source, [transformer])
-  t.throws(transpile, null, error.message)
+  t.throws(transpile, {
+    message: error.message
+  })
+})
+
+test('should throw if Component path is not found and failIfNotFound is true', (t) => {
+  const sourceCode = fs.readFileSync(resolve(__dirname, 'fixtures', 'component-not-found', 'index.ts'), 'utf-8')
+
+  const source = ts.createSourceFile('index.tsx', sourceCode, ts.ScriptTarget.ESNext, true)
+
+  const transformer = createTransformer({
+    libraryName: 'react',
+    failIfNotFound: true
+  })
+
+  const transpile = () => ts.transform(source, [transformer])
+  t.throws(transpile, {
+    message: 'Can not find component for library: react in react/lib/component'
+  });
 })

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -8,10 +8,16 @@ import transformerFactory, { Options } from '../src'
 export function createSpec(title: string, config: Options | Options[]) {
   const printer = ts.createPrinter()
 
-  const fixtureDir = fs.readdirSync(resolve(__dirname, 'fixtures'))
+  const fixtureDir = fs.readdirSync(resolve(__dirname, 'fixtures'), {
+    withFileTypes: true
+  })
 
   const transformer = transformerFactory(config)
-  fixtureDir.forEach(v => {
+  fixtureDir.forEach(vDirEnt => {
+    if (!vDirEnt.isFile()) {
+      return;
+    }
+    const v = vDirEnt.name;
     test(`${title} ${v}`, (t) => {
       const sourceCode = fs.readFileSync(resolve(__dirname, 'fixtures', v), 'utf-8')
 


### PR DESCRIPTION
 The build will fail if the component is not found.

Also, updated the README with a brief description of each option, please review to make sure they are accurate.

Resolve #918 