### PR TITLE
chore: use canonical public repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:Brooooooklyn/ts-import-plugin.git"
+    "url": "git+https://github.com/ts-plugin/ts-import-plugin.git"
   },
   "keywords": [
     "antd",


### PR DESCRIPTION
## Summary

- replace the SSH repository metadata with the canonical public HTTPS GitHub URL
- point the package metadata at the current `ts-plugin/ts-import-plugin` repository after the GitHub owner move

## Validation

- `node package metadata assertion`
- `git diff --check`
- `git ls-remote https://github.com/ts-plugin/ts-import-plugin.git HEAD`
- `node .yarn/releases/yarn-4.16.0.cjs install --immutable --mode=skip-build`
- `node .yarn/releases/yarn-4.16.0.cjs build`
- `node .yarn/releases/yarn-4.16.0.cjs test`
- `node .yarn/releases/yarn-4.16.0.cjs lint`
- `node .yarn/releases/yarn-4.16.0.cjs pack --dry-run`
